### PR TITLE
Bump default Riak version to v1.4.9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,4 +27,4 @@ riak_tune_disks: false
 riak_tune_os: false
 riak_scheduler: noop
 riak_search: "false"
-riak_version: 1.4.8
+riak_version: 1.4.9

--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -24,13 +24,13 @@ def local_ip
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |cluster|
-    cluster.vm.box = if ENV["ANSIBLE_RIAK_OS"] == "UBUNTU"
-      "chef/ubuntu-12.04"
-    elsif ENV["ANSIBLE_RIAK_OS"] == "CENTOS"
-      "chef/centos-6.5"
-    else
-      "chef/ubuntu-12.04"
-    end
+  cluster.vm.box = if ENV["ANSIBLE_RIAK_OS"] == "UBUNTU"
+    "chef/ubuntu-12.04"
+  elsif ENV["ANSIBLE_RIAK_OS"] == "CENTOS"
+    "chef/centos-6.5"
+  else
+    "chef/ubuntu-12.04"
+  end
 
   # Wire up the proxy
   if Vagrant.has_plugin?("vagrant-proxyconf")


### PR DESCRIPTION
In addition to the Riak version bump, there is a small code indentation fix.
