### PR TITLE
Add Debian support to example Vagrantfile

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -28,6 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |cluster|
     "chef/ubuntu-12.04"
   elsif ENV["ANSIBLE_RIAK_OS"] == "CENTOS"
     "chef/centos-6.5"
+  elsif ENV["ANSIBLE_RIAK_OS"] == "DEBIAN"
+    "chef/debian-7.4"
   else
     "chef/ubuntu-12.04"
   end

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,1 +1,1 @@
-basho.riak-common,v1.0.2
+basho.riak-common,v1.1.0


### PR DESCRIPTION
In addition to the initial support for Ubuntu and CentOS, now you can optionally set the `ANSIBLE_RIAK_OS` environmental variable to `DEBIAN` for a Wheezy based cluster.
