### PR TITLE
Ignore errors if sysctl fails; needed for running in restricted env

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: check proc writeable
-  register: proc_writeable
-  command: test -w /proc/sys/vm/swappiness
-  ignore_errors: yes
-
-- name: update sysctl
-  command: sysctl -e -p /etc/sysctl.d/riak.conf
-  when: proc_writeable|success
-
 - name: source rclocal
   command: /bin/bash /etc/rc.local
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,11 @@
 
 - name: copy custom riak package
   copy: src={{ riak_custom_package }} dest=/tmp
-  when: riak_custom_package != False and riak_custom_package.find('http') == -1 
+  when: riak_custom_package != False and riak_custom_package.find('http') == -1
 
 - name: copy custom riak package from remote
   action: get_url url={{ riak_custom_package }} dest=/tmp/
-  when: riak_custom_package != False and riak_custom_package.find('http') != -1 
+  when: riak_custom_package != False and riak_custom_package.find('http') != -1
 
 - name: set riak packagename
   set_fact: riak_package=/tmp/{{ riak_custom_package|basename }} state=present
@@ -43,7 +43,9 @@
 
 - name: configure sysctl
   template: src=etc_sysctl.d_riak.conf.j2 dest=/etc/sysctl.d/riak.conf owner=root group=root mode=0644
-  notify: check proc writeable
+  notify:
+    - check proc writeable
+    - update sysctl
 
 - name: copying custom beams
   copy: src={{ item }} dest="{{ riak_patch_dir }}/"


### PR DESCRIPTION
When provisioning Riak via Ansible in a constrained container environment, like modern version of Docker, access to `/proc` and `/sys` is locked down, which prevents `sysctl` from operating.

As far as I can tell, the `sysctl` commands here (and in `ansible-riak-common`) don't affect the installation, but are performance improvements.

So, ignoring errors here seems safe.

Let me know if this is reasonable (or if there is a better way). If so, I can make a similar pull request on `ansible-riak-common`.
