### PR TITLE
[fix] use custom http endpoints for riak commands

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,13 +9,13 @@
   wait_for: port={{ riak_http_port }}
 
 - name: wait for kv
-  riak: wait_for_service=kv
+  riak: wait_for_service=kv http_conn={{ riak_ip_addr }}:{{ riak_http_port }}
 
 - name: commit cluster changes
-  riak: command=commit
+  riak: command=commit http_conn={{ riak_ip_addr }}:{{ riak_http_port }}
 
 - name: wait for handoffs
-  riak: wait_for_handoffs=1200
+  riak: wait_for_handoffs=1200 http_conn={{ riak_ip_addr }}:{{ riak_http_port }}
 
 - name: wait for ring
-  riak: wait_for_ring=600
+  riak: wait_for_ring=600 http_conn={{ riak_ip_addr }}:{{ riak_http_port }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,8 +80,8 @@
   wait_for: port={{ riak_http_port }}
 
 - name: wait for riak_kv service to start
-  riak: wait_for_service=kv
+  riak: wait_for_service=kv http_conn={{ riak_ip_addr }}:{{ riak_http_port }}
 
 - name: ping riak
-  riak: command=ping
+  riak: command=ping http_conn={{ riak_ip_addr }}:{{ riak_http_port }}
   register: info


### PR DESCRIPTION
I'm starting using Ansible for some of my tasks and so I'm not very experienced with it. I lost several time looking for timeouts when running this role with custom configurations and as far as I could "debug" when you do it, changing settings like host and port require to also set http_conn parameter to riak module otherwise it will try to connect to the default host and port...

<!---
@huboard:{"order":6.5,"milestone_order":14,"custom_state":""}
-->
