### PR TITLE
changed riak_iface to read value from ansible hostvars

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ riak_custom_package: no
 riak_filesystem: ext4
 riak_handoff_port: 8099
 riak_http_port: 8098
-riak_iface: eth0
+riak_iface: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['interface'] }}"
 riak_ip_addr: "{{ hostvars[inventory_hostname]['ansible_' + riak_iface]['ipv4']['address'] }}"
 riak_node_name: "riak@{{ riak_ip_addr }}"
 riak_pb_bind_ip: 0.0.0.0


### PR DESCRIPTION
riak_iface is hardcoded to eth0
When I am installing Riak on centos-7 launched through vagrant the interface name is not eth0, but it is enp0s3, 
![screen shot 2015-05-15 at 11 52 27](https://cloud.githubusercontent.com/assets/1011536/7647843/e682ad28-faf8-11e4-8878-a0364d112752.png)

so changed this to read the interface name from hostvars instead of hardcoding it to eth0