### PR TITLE
Debian/Ubuntu 14.04 fixes

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -63,7 +63,9 @@ galaxy_info:
   #  - quantal
   #  - raring
   #  - saucy
-  #  - trusty
+    - trusty
+  #  - utopic
+  #  - vivid
   #- name: SLES
   #  versions:
   #  - all

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,7 +10,9 @@
   - curl
 
 - name: Install package cloud repo
-  shell: "curl https://packagecloud.io/install/repositories/basho/riak/script.deb | sudo bash"
+  shell: "curl -L https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | sudo bash"
+  args:
+    creates: /etc/apt/sources.list.d/basho_riak.list
   tags: Debian
 
 - name: Install Riak for Debian

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Make certain Riak is stopped
   service: name=riak state=stopped
+  ignore_errors: yes
+  # Will always fail if Riak has never been installed before
 
 - name: Execute RedHat OS family specific install
   include: RedHat.yml


### PR DESCRIPTION
This patchset fixes some showstopper bugs that prevent the role running at all successfully on Ubuntu 14.04 (trusty).

At time of writing, there are bugs later on that cause failures too, but these are, I believe, separate issues. (See issue #21 )