### PR TITLE
Minor tweaks for dev 2.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,13 +11,13 @@ riak_usr_lib:       /usr/lib
 
 riak_admin:   '/usr/sbin/riak-admin'
 
-riak_node_name:     'riak@127.0.0.1'
+riak_node_name:     'riak@{{ ansible_fqdn }}'
 
-riak_pb_bind_ip:    127.0.0.1
+riak_pb_bind_ip:    0.0.0.0
 riak_pb_port:       8087
 riak_pb_conf:       "{{ riak_pb_bind_ip }}:{{ riak_pb_port }}"
 
-riak_http_bind_ip:  127.0.0.1
+riak_http_bind_ip:  0.0.0.0
 riak_http_port:     8098
 riak_http_conf:     "{{ riak_http_bind_ip }}:{{ riak_http_port }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
   with_dict: riak_conf
 
 - name: Tag riak.conf as ansible managed
-  lineinfile: "dest=/etc/riak/riak.conf regexp='^## Ansible Managed.+$'  line='## Ansible Managed\n' insertbefore='BOF'"
+  lineinfile: dest=/etc/riak/riak.conf regexp='^## Ansible Managed.*$'  line='## Ansible Managed' insertbefore='BOF'
   tags: configfiles
 
 - name: Make certain Riak is set to start on boot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,8 +61,11 @@
   lineinfile: dest=/etc/riak/riak.conf regexp='^## Ansible Managed.*$'  line='## Ansible Managed' insertbefore='BOF'
   tags: configfiles
 
-- name: Make certain Riak is set to start on boot
+- name: Make certain Riak is started and set to start on boot
   service: name=riak enabled=yes state=started
+
+- name: Wait for Riak to start up before continuing
+  wait_for: delay=5 timeout=30 host={{ inventory_hostname }} port={{ riak_pb_port }} state=started
 
 - name: Bucket operations
   include: buckets.yml


### PR DESCRIPTION
These commits fix couple of obvious issues, and also introduce slightly more useful defaults for the nodes that will enable future improvements to the ansible role.
ie. Unique nodenames,and listening to IPs other than localhost.

One possibly could arise here -- if you don't HAVE a domain name, then riak will throw an error and refuse to start. I'm considering changing this code to effectively enforce a .localdomain domain name if you don't have one.. but would appreciate your own thoughts on this as it feels like a bad kludge.