### PR TITLE
Fixed ansible version check errors and apt install error

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -12,7 +12,8 @@
   - openjdk-7-jre
 
 - name: Fetch ansible ansible_version
-  command: ansible --version
+  sudo: false
+  local_action: shell ansible --version
   register: ans_ver
 
 - name: Add Package Cloud repository key without validation
@@ -29,7 +30,7 @@
   template: src=deb_repo.list.j2 dest=/etc/apt/sources.list.d/basho_riak.list owner=root group=root mode=0644
 
 - name: Install Riak for Debian
-  apt: name={{ riak_package }} state=present  update_cache=yes cache_valid_time=3600
+  apt: name={{ riak_package }} state=present update_cache=yes
   tags: Debian
 
 - name: Set the riak ulimit for Debian


### PR DESCRIPTION
As discovered while looking into #31:

----

Fixed ansible version check errors when ansible is not installed on the remote.

Fixed "msg: No package matching 'riak' is available" error by removing cache
duration from apt install command.