### PR TITLE
Only create bucket types when the variable is defined.

### DIFF
--- a/tasks/buckets.yml
+++ b/tasks/buckets.yml
@@ -6,9 +6,9 @@
 - name: Create bucket types only if not found in list
   command: '{{ riak_admin }} bucket-type create {{ item.name }} ''{{ item.props }}'''
   with_items: riak_bucket_types
-  when: types.stdout.find(item.name) < 0
+  when: riak_bucket_types is defined and types.stdout.find(item.name) < 0
 
 - name: Activate bucket types that are not active
   command: '{{ riak_admin }} bucket-type activate {{ item.name }}'
   with_items: riak_bucket_types
-  when: types.stdout.find(item.name + " (active)") < 0
+  when: riak_bucket_types is defined and types.stdout.find(item.name + " (active)") < 0


### PR DESCRIPTION
Only create bucket types when the variable is defined.

Fixes the following error:

    fatal: [1.2.3.4] => Failed to template {% if types.stdout.find(item.name) < 0 %} True {% else %} False {% endif %}: an unexpected type error occurred. Error was expected a character buffer object.

Discovered while looking into issue #31.