### PR TITLE
Fix undefined error on copy beams

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,10 +29,8 @@
 - name: configure sysctl
   template: src=etc_sysctl.d_riak.conf.j2 dest=/etc/sysctl.d/riak.conf owner=root group=root mode=0644
 
-- name: copying custom beams
-  copy: "src={{ item }} dest={{ riak_patch_dir }}/"
-  with_fileglob:
-    - "{{riak_custom_beams_dir}}/*.beam"
+- name: copy custom beams
+  synchronize: src={{ riak_custom_beams_dir }} dest={{ riak_patch_dir }}
   when: riak_custom_beams_dir is defined
 
 - name: Check if this is first pass


### PR DESCRIPTION
On some versions of ansible, the way the copying of custom beams is set up causes:
```
[DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this
 will be a fatal error.. This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```
and the play continues to run without issue. On others, the play just fails on that task.
