### PR TITLE
TravisCI, Remove obsolete code & fix packagecloud implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+---
+language: python
+python: "2.7"
+
+sudo: required
+dist: trusty
+
+addons:
+  hosts:
+    - riak-test
+
+install:
+  - sudo apt-get install -y software-properties-common python-software-properties
+  - sudo add-apt-repository -y ppa:ansible/ansible
+  - sudo apt-get update -y
+  - sudo apt-get install -y ansible
+  - echo 'riak-test' | sudo tee -a /etc/ansible/hosts
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - 'printf "[defaults]\nroles_path=../" > ansible.cfg'
+
+env:
+  - ANSIBLE_HOST_KEY_CHECKING=False
+
+script:
+  - ansible-playbook tests/test.yml -v
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  slack:
+    secure: ZtgcjTxhTxrzWW6MIHLRtucW/BMm42RKS3nGRtSfgER9rx7oJ0Y9gOYkh1FM0GsM7Z11Q/iDhWs/8WTccAV0PrMZ6KHaq54wGmfYyqwPM4YreUwQ87PnOW4wZbl0TJTeWutasEwZvnVJ8VEyyQcS2PHt0zlsENn0XWvobvaZ+FM=

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,18 +15,19 @@ riak_conf_template: riak.conf.j2
 
 riak_node_name:     'riak@{{ ansible_fqdn }}'
 
-riak_ring_size:     64
-
-riak_backend:   bitcask
-
 riak_pb_bind_ip:    0.0.0.0
 riak_pb_port:       8087
 
 riak_http_bind_ip:  0.0.0.0
 riak_http_port:     8098
 
-riak_control:   "off"
-riak_search:   "off"
+riak_https_bind_ip: 0.0.0.0
+riak_https_port:    10011
+
+riak_ring_size:     64
+riak_backend:       bitcask
+riak_control:       'off'
+riak_search:        'off'
 
 riak_leveldb_max_mem_percent:   70
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,6 +34,8 @@ riak_net_speed:     1Gb
 
 riak_anti_entropy: active
 
+riak_security_enabled: false
+
 # riak_shell configuration
 riak_shell_group: 'riak'
 riak_shell_interface: 'ansible_eth0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,5 +86,6 @@ riak_scheduler:     noop
 # Create permission grants
 #
 #riak_grants:
-#  - {subject: 'user', bucket_type: 'certificate', bucket: '', permissions: ''}
-#  - {subject: 'group', bucket_type: 'password', bucket: '', permissions: ''}
+#  - {subject: 'all', scope: 'any', permissions: ''}
+#  - {subject: 'user', scope: 'mybuckettype', permissions: ''}
+#  - {subject: 'group', scope: 'mybuckettype mybucket', permissions: ''}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,6 @@
 riak_package:       riak
 
 riak_enterprise:    false
-riak_usr_lib:       /usr/lib
 
 riak_admin:   '/usr/sbin/riak-admin'
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: "Installs and configures Riak KV and TS, a distributed, highly available NoSQL and TimeSeries database."
   company: Basho
   license: Apache
-  min_ansible_version: 2.0
+  min_ansible_version: 2.1
   platforms:
   - name: EL
     versions:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -11,19 +11,9 @@
   - apt-transport-https
   - openjdk-7-jre
 
-- name: Fetch ansible ansible_version
-  local_action: shell ansible --version
-  register: ans_ver
-
 - name: Add Package Cloud repository key without validation
   apt_key: url=https://packagecloud.io/gpg.key state=present validate_certs=no
   tags: Debian
-  when: ans_ver.stdout.find(' 1.5.') > 0
-
-- name: Add Package Cloud repository key with validation
-  apt_key: url=https://packagecloud.io/gpg.key state=present
-  tags: Debian
-  when: ans_ver.stdout.find(' 1.5.') < 0
 
 - name: Add Basho Riak repository (hosted at Package Cloud)
   template: src=deb_repo.list.j2 dest=/etc/apt/sources.list.d/basho_riak.list owner=root group=root mode=0644

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -5,18 +5,34 @@
   with_items:
   - curl
   - apt-transport-https
-  - openjdk-7-jre
+  - default-jre
+
+- name: Check if Riak is installed
+  stat: path=/etc/riak/riak.conf
+  register: dist
 
 - name: Add Package Cloud repository key without validation
   apt_key: url=https://packagecloud.io/gpg.key state=present validate_certs=no
   tags: Debian
+  when:
+    - not dist.stat.exists
 
 - name: Add Basho Riak repository (hosted at Package Cloud)
   template: src=deb_repo.list.j2 dest=/etc/apt/sources.list.d/basho_riak.list owner=root group=root mode=0644
+  when:
+    - not dist.stat.exists
 
 - name: Install Riak for Debian
-  package: name={{ riak_package }} state=present update_cache=yes
+  package: "name={{ riak_package }} state=present update_cache=yes"
   tags: Debian
+  when: "'deb' not in riak_package"
+
+- name: Install Riak for Debian
+  apt: "deb={{ riak_package }}"
+  tags: Debian
+  when:
+    - "'deb' in riak_package"
+    - not dist.stat.exists
 
 - name: Set the riak ulimit for Debian
   copy: src=etc_default_riak_ulimit dest=/etc/default/riak owner=riak group=riak

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,8 +1,4 @@
 ---
-- name: Include DEB vars
-  include_vars: Debian.yml
-  tags: Debian
-
 - name: Install Pre-requisites
   package: name={{ item }} state=present update_cache=yes cache_valid_time=3600
   tags: Debian

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,8 +1,4 @@
 ---
-- name: Include RHEL vars
-  include_vars: RedHat.yml
-  tags: RedHat
-
 - name: "Install Java & libselinux-python"
   package: "name={{ item }} state=present"
   tags: RedHat

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -16,7 +16,8 @@
 - name: Install package cloud repo if Riak is not already installed
   command: '/tmp/packagecloud_rpm.sh'
   tags: RedHat
-  when: not dist.stat.exists
+  when:
+    - not dist.stat.exists
 
 - name: Install Riak for RedHat
   package: "name={{ riak_package }} state=present"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,27 +33,8 @@
   synchronize: src={{ riak_custom_beams_dir }} dest={{ riak_patch_dir }}
   when: riak_custom_beams_dir is defined
 
-- name: Check if this is first pass
-  stat: path=/etc/riak/riak.conf.dist
-  register: dist
-
-- name: Check if this is first pass
-  stat: path=/etc/riak/riak_shell.config.dist
-  register: distts
-  when: riak_package == "riak-ts"
-
-- name: preserve distribution copy of riak.conf if not already done
-  command: "cp -i /etc/riak/riak.conf /etc/riak/riak.conf.dist"
-  tags: configfiles
-  when: not dist.stat.exists
-
-- name: preserve distribution copy of riak_shell.config if not already done
-  command: "cp -i /etc/riak/riak_shell.config /etc/riak/riak_shell.config.dist"
-  tags: configfiles
-  when: riak_package == "riak-ts" and not distts.stat.exists
-
 - name: install riak.conf with templated configuration
-  template: src={{ riak_conf_template }} dest=/etc/riak/riak.conf owner=root group=root mode=0444
+  template: src={{ riak_conf_template }} dest=/etc/riak/riak.conf owner=root group=root mode=0444 backup=yes
   notify: restart riak
 
 - name: install riak_shell.config with templated configuration

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,15 +30,15 @@
   template: src=etc_sysctl.d_riak.conf.j2 dest=/etc/sysctl.d/riak.conf owner=root group=root mode=0644
 
 - name: copy custom beams
-  synchronize: src={{ riak_custom_beams_dir }} dest={{ riak_patch_dir }}
+  synchronize: "src={{ riak_custom_beams_dir }} dest={{ riak_patch_dir }}"
   when: riak_custom_beams_dir is defined
 
 - name: install riak.conf with templated configuration
-  template: src={{ riak_conf_template }} dest=/etc/riak/riak.conf owner=root group=root mode=0444 backup=yes
+  template: "src={{ riak_conf_template }} dest=/etc/riak/riak.conf owner=root group=root mode=0444 backup=yes"
   notify: restart riak
 
 - name: install riak_shell.config with templated configuration
-  template: src={{ riak_shell_conf_template }} dest=/etc/riak/riak_shell.config owner=root group=root mode=0444
+  template: "src={{ riak_shell_conf_template }} dest=/etc/riak/riak_shell.config owner=root group=root mode=0444"
   when: riak_package == "riak-ts" and riak_shell_nodes is defined
   notify: restart riak
 
@@ -46,7 +46,7 @@
   service: name=riak enabled=yes state=started
 
 - name: Wait for Riak to start up before continuing
-  wait_for: delay=5 timeout=30 host={{ riak_pb_bind_ip }} port={{ riak_pb_port }} state=started
+  wait_for: "delay=5 timeout=30 host={{ riak_pb_bind_ip }} port={{ riak_pb_port }} state=started"
 
 - name: Bucket operations
   include: buckets.yml

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -1,6 +1,7 @@
 ---
 - name: Enable Security
   command: '{{ riak_admin }} security enable'
+  when: riak_security_enabled
 
 - name: Create Groups
   command: '{{ riak_admin }} security add-group {{ item }}'

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -15,7 +15,7 @@
 - name: Create users
   command: '{{ riak_admin }} security add-user {{ item.user }} password={{ item.password }}'
   with_items: "{{ riak_users }}"
-  when: (riak_users is defined) and (riak_groups is not defined) 
+  when: (riak_users is defined) and (riak_groups is not defined)
 
 - name: Create security sources
   command: '{{ riak_admin }} security add-source {{ item.user }} {{ item.cidr }} {{ item.type }}'
@@ -23,6 +23,6 @@
   when: riak_sources is defined
 
 - name: Set security permissions
-  command: '{{ riak_admin }} security grant {{ item.permissions }} on {{ item.container }} to {{ item.subject }}'
+  command: '{{ riak_admin }} security grant {{ item.permissions }} on {{ item.scope }} to {{ item.subject }}'
   with_items: '{{ riak_grants }}'
   when: riak_grants is defined

--- a/templates/packagecloud_rpm.sh.j2
+++ b/templates/packagecloud_rpm.sh.j2
@@ -89,7 +89,7 @@ main ()
   curl_check
 
 
-  yum_repo_config_url="https://packagecloud.io/install/repositories/basho/{{ riak_package }}/config_file.repo?os=${os}&dist=${dist}&source=script"
+  yum_repo_config_url="https://packagecloud.io/install/repositories/basho/{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}/config_file.repo?os=${os}&dist=${dist}&source=script"
 
   yum_repo_path=/etc/yum.repos.d/basho_{{ riak_package }}.repo
 
@@ -141,7 +141,7 @@ main ()
   fi
 
   echo "Installing pygpgme to verify GPG signatures..."
-  yum install -y pygpgme --disablerepo='basho_{{ riak_package }}'
+  yum install -y pygpgme --disablerepo='basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}'
   pypgpme_check=`rpm -qa | grep -qw pygpgme`
   if [ "$?" != "0" ]; then
     echo
@@ -152,11 +152,11 @@ main ()
     echo
 
     # set the repo_gpgcheck option to 0
-    sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/basho_{{ riak_package }}.repo
+    sed -i'' 's/repo_gpgcheck=1/repo_gpgcheck=0/' /etc/yum.repos.d/basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}.repo
   fi
 
   echo "Installing yum-utils..."
-  yum install -y yum-utils --disablerepo='basho_{{ riak_package }}'
+  yum install -y yum-utils --disablerepo='basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}'
   yum_utils_check=`rpm -qa | grep -qw yum-utils`
   if [ "$?" != "0" ]; then
     echo
@@ -165,8 +165,8 @@ main ()
     echo
   fi
 
-  echo "Generating yum cache for basho_{{ riak_package }}..."
-  yum -q makecache -y --disablerepo='*' --enablerepo='basho_{{ riak_package }}'
+  echo "Generating yum cache for basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}..."
+  yum -q makecache -y --disablerepo='*' --enablerepo='basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}'
 
   echo
   echo "The repository is setup! You can now install packages."

--- a/templates/packagecloud_rpm.sh.j2
+++ b/templates/packagecloud_rpm.sh.j2
@@ -91,7 +91,7 @@ main ()
 
   yum_repo_config_url="https://packagecloud.io/install/repositories/basho/{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}/config_file.repo?os=${os}&dist=${dist}&source=script"
 
-  yum_repo_path=/etc/yum.repos.d/basho_{{ riak_package }}.repo
+  yum_repo_path=/etc/yum.repos.d/basho_{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}.repo
 
   echo "Downloading repository file: ${yum_repo_config_url}"
 

--- a/templates/riak.conf.j2
+++ b/templates/riak.conf.j2
@@ -501,4 +501,3 @@ search.solr.jmx_port = 8985
 ## Acceptable values:
 ##   - text
 search.solr.jvm_options = -d64 -Xms1g -Xmx1g -XX:+UseStringCache -XX:+UseCompressedOops
-

--- a/templates/riak.conf.j2
+++ b/templates/riak.conf.j2
@@ -313,7 +313,7 @@ listener.protobuf.internal = {{ riak_pb_bind_ip }}:{{ riak_pb_port }}
 ##
 ## Acceptable values:
 ##   - an IP/port pair, e.g. 127.0.0.1:10011
-## listener.https.internal = 127.0.0.1:8098
+{% if not riak_security_enabled %}#{% endif %}listener.https.internal = {{ riak_https_bind_ip }}:{{ riak_https_port }}
 
 ## How Riak will repair out-of-sync keys. Some features require
 ## this to be set to 'active', including search.

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,36 @@
+---
+- hosts: riak-test
+  connection: local
+  become: yes
+  become_method: sudo
+  roles:
+    - ansible-riak
+  vars:
+    riak_node_name: "riak@127.0.0.1"
+    riak_pb_bind_ip: 127.0.0.1
+    riak_pb_port:    8087
+    riak_http_bind_ip: 127.0.0.1
+    riak_http_port:    8098
+
+    riak_bucket_types:
+      - { name: counters, props: '{"props":{"datatype":"counter"}}' }
+      - { name: maps, props: '{"props":{"datatype":"map"}}' }
+      - { name: sets, props: '{"props":{"datatype":"set"}}' }
+
+    riak_users:
+      - {user: 'riakuser', password: '', cert: '', groups: ''}
+      - {user: 'riakpass', password: 'Test1234', cert: '', groups: ''}
+      - {user: 'riakadmin', password: '', cert: '', groups: 'admins'}
+      - {user: 'riakdeveloper', password: '', cert: '', groups: 'developers'}
+
+    riak_groups:
+      - admins
+      - developers
+
+    riak_sources:
+      - {user: 'riakuser', type: 'certificate', cidr: '0.0.0.0/0'}
+      - {user: 'riakpass', type: 'password', cidr: '0.0.0.0/0'}
+
+    riak_grants:
+      - {subject: 'riakuser', container: 'any', permissions: 'riak_kv.get,riak_kv.put'}
+      - {subject: 'riakpass', container: 'any', permissions: 'riak_kv.get,riak_kv.put'}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -32,5 +32,5 @@
       - {user: 'riakpass', type: 'password', cidr: '0.0.0.0/0'}
 
     riak_grants:
-      - {subject: 'riakuser', container: 'any', permissions: 'riak_kv.get,riak_kv.put'}
-      - {subject: 'riakpass', container: 'any', permissions: 'riak_kv.get,riak_kv.put'}
+      - {subject: 'riakuser', scope: 'any', permissions: 'riak_kv.get,riak_kv.put'}
+      - {subject: 'riakpass', scope: 'any', permissions: 'riak_kv.get,riak_kv.put'}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,0 @@
----
-riak_usr_lib: /usr/lib

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,2 +1,0 @@
----
-riak_usr_lib: /usr/lib64


### PR DESCRIPTION
- Fix Packagecloud script for RedHat so that alternate package versions can be called.
- Change the container keyword for security from container to scope to reduce confusion. Addresses #53 
- Remove Ansible version specific tasks, fixes #49 
- Configure riak.conf template task to use the backup feature, remove manual backup file creation. Fixes #56 
- Implements a new variable setting security to false by default to address #58 
- Implemented support for allowing `deb` packages as `riak_package` both local and remote to address #40 (requires Ansible 2.1+)
- Implemented TravisCI