### PR TITLE
Fix bug & force immediate reboot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,15 +32,13 @@
 
 - name: install riak.conf with templated configuration
   template: "src={{ riak_conf_template }} dest=/etc/riak/riak.conf owner=root group=root mode=0444 backup=yes"
-  notify: restart riak
 
 - name: install riak_shell.config with templated configuration
   template: "src={{ riak_shell_conf_template }} dest=/etc/riak/riak_shell.config owner=root group=root mode=0444"
   when: riak_package == "riak-ts" and riak_shell_nodes is defined
-  notify: restart riak
 
-- name: Make certain Riak is started and set to start on boot
-  service: name=riak enabled=yes state=started
+- name: Reboot Riak to accept the new config and ensure it is enabled to start at bootup
+  service: name=riak enabled=yes state=restarted
 
 - name: Wait for Riak to start up before continuing
   wait_for: "delay=5 timeout=30 host={{ riak_pb_bind_ip }} port={{ riak_pb_port }} state=started"

--- a/templates/deb_repo.list.j2
+++ b/templates/deb_repo.list.j2
@@ -1,2 +1,2 @@
-deb https://packagecloud.io/basho/{{ riak_package }}/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main
-deb-src https://packagecloud.io/basho/{{ riak_package }}/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main
+deb https://packagecloud.io/basho/{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main
+deb-src https://packagecloud.io/basho/{% if 'riak-ts' in riak_package %}riak-ts{% else %}riak{% endif %}/{{ ansible_distribution|lower }}/ {{ ansible_distribution_release }} main


### PR DESCRIPTION
- Fix bug for debian distros where if using a url for a package, the packagecloud repo would be broken
- Change the reboot of Riak after config update from notify handler to immediately after config update task