### PR TITLE
Cater for potential preference for runit

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,6 +65,9 @@ riak_tune_disks:    false
 riak_tune_os:       false
 riak_scheduler:     noop
 
+# riak_os_init: runit
+# riak_runit_service_dir: /var/service
+
 
 # Create bucket types
 #

--- a/files/etc_service_riak_run
+++ b/files/etc_service_riak_run
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec /sbin/setuser riak "$(ls -d /usr/lib/riak/erts*)/bin/run_erl" "/tmp/riak" \
+     "/var/log/riak" "exec /usr/sbin/riak console"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,6 @@
 - name: run riak_disk_tune
   command: /bin/bash /usr/local/bin/riak_disk_tune.sh
 
-- name: restart riak
-  service: name=riak state=restarted
-
 - name: wait for http
   wait_for: port={{ riak_http_port }}
 

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -63,4 +63,4 @@
 - name: Reload systemd
   systemd: state=restarted daemon_reload=yes name=riak enabled=yes
   tags: Debian
-  when: 'ansible_distribution_release == "xenial" or ansible_distribution_release == "jessie"'
+  when: '(ansible_distribution_release == "xenial" or ansible_distribution_release == "jessie") and (riak_os_init != "runit")'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,14 @@
   include: Debian.yml
   when: ansible_os_family == 'Debian'
 
+- name: Create Riak runit service directory
+  file: dest="{{ riak_runit_service_dir | mandatory }}/riak" state=directory
+  when: 'riak_os_init == "runit"'
+
+- name: Create Riak runit service
+  copy: src=etc_service_riak_run dest="{{ riak_runit_service_dir | mandatory }}/riak/run" owner=root group=root mode=0755
+  when: 'riak_os_init == "runit"'
+
 - name: mount the riak volume with optmized settings
   mount: name={{ riak_mountpoint }} src={{ riak_partition }} opts="{{riak_mount_options}}" fstype="{{riak_filesystem}}" state=mounted
   when: riak_tune_disks
@@ -43,6 +51,11 @@
 
 - name: Reboot Riak to accept the new config and ensure it is enabled to start at bootup
   service: name=riak enabled=yes state=restarted
+  when: 'riak_os_init != "runit"'
+
+- name: Reboot Riak to accept the new config and ensure it is enabled to start at bootup
+  command: sv restart riak
+  when: 'riak_os_init == "runit"'
 
 - name: Wait for Riak to start up before continuing
   wait_for: "delay=5 timeout=30 host={{ riak_pb_bind_ip }} port={{ riak_pb_port }} state=started"


### PR DESCRIPTION
Closes #70.

Opened issue while having the PR already ready... because when opening the PR I read the [guidelines](https://github.com/basho-labs/ansible-riak/blob/6c9ede59d22a0ed96d5fdcb475449532bc44434a/CONTRIBUTING.md#how-to-contribute-to-the-ansible-riak-role).