### PR TITLE
Add var to bypass init system reboot / enabling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ riak_anti_entropy: active
 
 riak_security_enabled:  false
 riak_install_java:      true
+riak_init_system:       system
 
 # Debian
 # riak_java_package: default-jre

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,6 @@
 - name: run riak_disk_tune
   command: /bin/bash /usr/local/bin/riak_disk_tune.sh
 
-- name: restart riak
-  service: name=riak state=restarted
-
 - name: wait for http
   wait_for: port={{ riak_http_port }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
 
 - name: Reboot Riak to accept the new config and ensure it is enabled to start at bootup
   service: name=riak enabled=yes state=restarted
+  when: riak_init_system == 'system'
 
 - name: Wait for Riak to start up before continuing
   wait_for: "delay=5 timeout=30 host={{ riak_pb_bind_ip }} port={{ riak_pb_port }} state=started"


### PR DESCRIPTION
This is to allow users to run Riak through an alternate init system. #70 