### PR TITLE
Fix execution for Riak KV - both on Travis CI and locally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ riak_init_system:       system
 riak_shell_group: 'riak'
 riak_shell_interface: 'ansible_eth0'
 riak_shell_conf_template: riak_shell.config.j2
-riak_shell_nodes_list: "{% for host in groups[riak_shell_group] %}riak@{{ hostvars[host][riak_shell_interface]['ipv4']['address'] }} {% endfor %}"
+riak_shell_nodes_list: "{% for host in groups[riak_shell_group]|default([]) %}riak@{{ hostvars[host][riak_shell_interface]['ipv4']['address'] }} {% endfor %}"
 riak_shell_nodes: "{{ riak_shell_nodes_list.split() }}"
 
 # disc tuning


### PR DESCRIPTION
Issue appears to be subtle change in probably undefined behaviour of
Ansible from in 2.2.2.0 as compared to 2.2.1.0.  Last CI successful
build and current CI failing build have this Ansible version
difference.  And locally I recently upgraded Ansible and shortly
afterwards I noticed issue too.

Change is based on:
* https://docs.ansible.com/ansible/playbooks_variables.html#magic-variables-and-how-to-access-information-about-other-hosts
* https://docs.ansible.com/ansible/playbooks_variables.html#jinja2-filters
* https://stackoverflow.com/questions/28885184/default-value-for-dictionary-in-jinja2-ansible#28885760